### PR TITLE
Update clipboard style and add enter animation

### DIFF
--- a/src/components/molecules/Clipboard.tsx
+++ b/src/components/molecules/Clipboard.tsx
@@ -11,12 +11,12 @@ type Props = {
 }
 
 export const Clipboard: FC<Props> = ({ name, children, pinColor }) => {
-  const rollingDgree = `${Math.floor(Math.random() * (40 + 1 - 10)) + 15}deg`
+  const rollingDegree = `${Math.floor(Math.random() * (40 + 1 - 15)) + 15}deg`
 
   return (
     // NOTE: styleプロパティからCSS変数を追加するためts-ignoreしている。
     // @ts-ignore
-    <div className={styles.clipboard} style={{ '--rolling-degree': rollingDgree, ...(pinColor && { '--pin-color': pinColor }) }}>
+    <div className={styles.clipboard} style={{ '--rolling-degree': rollingDegree, ...(pinColor && { '--pin-color': pinColor }) }}>
       <div className={styles.clipboard__pin} />
 
       <div className={styles.clipboard__contents}>

--- a/src/components/molecules/Clipboard.tsx
+++ b/src/components/molecules/Clipboard.tsx
@@ -7,26 +7,25 @@ import type { FC, ReactNode } from 'react'
 type Props = {
   name: string
   children: ReactNode
+  pinColor?: string
 }
 
-export const Clipboard: FC<Props> = ({ name, children }) => (
-  <div className={styles.clipboard}>
-    <div className={styles.clipboard__pins}>
-      <span className={styles['clipboard__pins--left']} />
-      <span className={styles['clipboard__pins--right']} />
-    </div>
+export const Clipboard: FC<Props> = ({ name, children, pinColor }) => {
+  const rollingDgree = `${Math.floor(Math.random() * (40 + 1 - 10)) + 15}deg`
 
-    <div className={styles.clipboard__contents}>
-      <h1 className={styles.clipboard__title}>
-        <span className={styles.clipboard__name}>{name}</span>
-        <span className={styles.clipboard__date}>{getNowDateString()}</span>
-      </h1>
-      <div className={styles.clipboard__note}>{children}</div>
-    </div>
+  return (
+    // NOTE: styleプロパティからCSS変数を追加するためts-ignoreしている。
+    // @ts-ignore
+    <div className={styles.clipboard} style={{ '--rolling-degree': rollingDgree, ...(pinColor && { '--pin-color': pinColor }) }}>
+      <div className={styles.clipboard__pin} />
 
-    <div className={styles.clipboard__pins}>
-      <span className={styles['clipboard__pins--left']} />
-      <span className={styles['clipboard__pins--right']} />
+      <div className={styles.clipboard__contents}>
+        <h1 className={styles.clipboard__title}>
+          <span className={styles.clipboard__name}>{name}</span>
+          <span className={styles.clipboard__date}>{getNowDateString()}</span>
+        </h1>
+        <div className={styles.clipboard__note}>{children}</div>
+      </div>
     </div>
-  </div>
-)
+  )
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,3 +19,17 @@ a {
   height: 100%;
   overflow: hidden auto;
 }
+
+:root {
+  --primary-main: #2196f3;
+  --primary-dark: #0069c0;
+  --primary-light: #6ec6ff;
+
+  --secondary-main: #ef5350;
+  --secondary-dark: #b61827;
+  --secondary-light: #ff867c;
+
+  /* NOTE: max-widthで使う各デバイス上限のbreakpoint。 */
+  --breakpoint-sm: 414px;
+  --breakpoint-md: 834px;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,17 +19,3 @@ a {
   height: 100%;
   overflow: hidden auto;
 }
-
-:root {
-  --primary-main: #2196F3;
-  --primary-dark: #0069c0;
-  --primary-light: #6ec6ff;
-
-  --secondary-main: #ef5350;
-  --secondary-dark: #b61827;
-  --secondary-light: #ff867c;
-
- /* NOTE: max-widthで使う各デバイス上限のbreakpoint。 */
-  --breakpoint-sm: 414px;
-  --breakpoint-md: 834px;
-}

--- a/src/styles/modules/Clipboard.module.css
+++ b/src/styles/modules/Clipboard.module.css
@@ -1,43 +1,34 @@
 .clipboard {
-  border: 1px solid #ccc;
-  padding: 0.5rem;
+  position: relative;
+  z-index: 1;
+  background-color: #fff;
 }
 
-.clipboard__pins {
-  display: flex;
-  justify-content: space-between;
-}
-.clipboard__pins--left {
-  position: relative;
-  transform-origin: top;
-  transform: rotate(-20deg);
-  width: 1px;
-  height: 10px;
+.clipboard__pin {
+  position: absolute;
+  top: 15px;
+  left: 50%;
+  transform-origin: center bottom;
+  transform: rotate(30deg) translateX(50%);
+  width: 1.5px;
+  height: 15px;
   background-color: #444;
 }
-.clipboard__pins--right {
-  position: relative;
-  transform-origin: top;
-  transform: rotate(20deg);
-  width: 1px;
-  height: 10px;
-  background-color: #444;
-}
-.clipboard__pins--right::before, .clipboard__pins--left::before {
-  content: "";
+.clipboard__pin::before {
+  content: '';
   display: block;
   position: absolute;
   top: 0;
   left: 0;
   transform: translate(-50%, -50%);
-  width: 10px;
-  height: 10px;
+  width: 20px;
+  height: 20px;
   border-radius: 100vh;
-  background-color: var(--secondary-main);
-  box-shadow: -5px 5px 10px #827d7d;
+  background-color: var(--pin-color, var(--secondary-main));
+  box-shadow: -7.5px 7.5px 12.5px #827d7d;
 }
-.clipboard__pins--right::after, .clipboard__pins--left::after {
-  content: "";
+.clipboard__pin::after {
+  content: '';
   display: block;
   position: absolute;
   top: -3px;
@@ -50,9 +41,27 @@
 }
 
 .clipboard__contents {
-  font-family: "New Tegomin";
+  font-family: 'New Tegomin';
   font-weight: 550;
-  padding: 1.25rem;
+  border: 1px solid #ccc;
+  transform-origin: center 15px;
+  animation: rolling 2s ease-in-out;
+  padding: 1.5rem 1.25rem;
+}
+@keyframes rolling {
+  0% {
+    transform: rotate(var(--rolling-degree, 30deg));
+    box-shadow: 0 10px 15px #827d7d;
+  }
+  25% {
+    transform: rotate(calc(var(--rolling-degree, 30deg) - 45deg));
+  }
+  50% {
+    transform: rotate(calc(var(--rolling-degree, 30deg) - 20deg));
+  }
+  75% {
+    transform: rotate(calc(var(--rolling-degree, 30deg) - 35deg));
+  }
 }
 
 .clipboard__title {
@@ -95,7 +104,7 @@
   }
 }
 .clipboard__note::before {
-  content: "";
+  content: '';
   display: block;
   position: absolute;
   top: 0;


### PR DESCRIPTION
<!-- 標準的なテンプレートなので、必ずしも埋める必要はない -->

## 関連 URL(jira/wiki/issue)
#2 
## 内容・背景
- クリップボードのUIを4つ止めのピンから一つ止めの画鋲に変更。
- ↑の画鋲を起点に横揺れのアニメーションを追加。

## 変更点

<!-- 画面キャプチャや動画があれば添付する -->

### as-is
https://user-images.githubusercontent.com/54551190/192113656-7684c0c7-a464-45de-bf0b-6142f5fbf5ca.mp4

### to-be
https://user-images.githubusercontent.com/54551190/192113679-e62cc526-60de-4aff-a645-73dc4445a5b1.mp4

## テスト方法
skillページへ行き来する。
<!-- 動作確認の手順を記載する、画面キャプチャや動画もあれば添付する、テストコードの内容を記載しても可 -->

## レビュー観点

<!-- レビューする際の注意点や、詳しく見てほしい点などを記載する -->
