### PR TITLE
change clipboard ui to loose leaf style

### DIFF
--- a/src/styles/modules/Clipboard.module.css
+++ b/src/styles/modules/Clipboard.module.css
@@ -41,12 +41,25 @@
 }
 
 .clipboard__contents {
+  position: relative;
   font-family: 'New Tegomin';
   font-weight: 550;
   border: 1px solid #ccc;
+  border-radius: 10px;
   transform-origin: center 15px;
   animation: rolling 2s ease-in-out;
-  padding: 1.5rem 1.25rem;
+  padding: 2.75rem 1.25rem 1.5rem 2.75rem;
+}
+.clipboard__contents::before {
+  content: '';
+  display:  block;
+  position: absolute;
+  border-left: dotted 20px #ccc;
+  height: 95%;
+  top: 50%;
+  left: 10px;
+  transform: translateY(-50%);
+  z-index: 1;
 }
 @keyframes rolling {
   0% {

--- a/src/styles/modules/Clipboard.module.css
+++ b/src/styles/modules/Clipboard.module.css
@@ -45,7 +45,7 @@
   font-family: 'New Tegomin';
   font-weight: 550;
   border: 1px solid #ccc;
-  transform-origin: center 17.5px;
+  transform-origin: center 32.5px;
   animation: rolling 2s ease-in-out;
   padding: 1.5rem 1.25rem;
 }

--- a/src/styles/modules/Clipboard.module.css
+++ b/src/styles/modules/Clipboard.module.css
@@ -8,10 +8,11 @@
   position: absolute;
   top: 15px;
   left: 50%;
+  z-index: 2;
   transform-origin: center bottom;
   transform: rotate(30deg) translateX(50%);
   width: 1.5px;
-  height: 15px;
+  height: 17.5px;
   background-color: #444;
 }
 .clipboard__pin::before {
@@ -21,8 +22,8 @@
   top: 0;
   left: 0;
   transform: translate(-50%, -50%);
-  width: 20px;
-  height: 20px;
+  width: 25px;
+  height: 25px;
   border-radius: 100vh;
   background-color: var(--pin-color, var(--secondary-main));
   box-shadow: -7.5px 7.5px 12.5px #827d7d;
@@ -31,12 +32,12 @@
   content: '';
   display: block;
   position: absolute;
-  top: -3px;
-  left: 0;
-  width: 3px;
-  height: 3px;
+  top: -7.5px;
+  left: 2.5px;
+  width: 5px;
+  height: 5px;
   border-radius: 100vh;
-  filter: blur(0.3px);
+  filter: blur(1px);
   background-color: #fff;
 }
 
@@ -44,7 +45,7 @@
   font-family: 'New Tegomin';
   font-weight: 550;
   border: 1px solid #ccc;
-  transform-origin: center 15px;
+  transform-origin: center 17.5px;
   animation: rolling 2s ease-in-out;
   padding: 1.5rem 1.25rem;
 }
@@ -91,11 +92,14 @@
 
 .clipboard__note {
   position: relative;
+  /* 実際のルーズリーフの比率 1 : √2 */
+  aspect-ratio: 1/ 1.41421356;
   line-height: 30px;
   overflow-wrap: break-word;
   background: linear-gradient(var(--primary-main) 1px, transparent 1px) #fff top left / auto 30px;
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
+  overflow: auto;
   padding: 0 0.5rem;
 }
 @media (max-width: var(--breakpoint-sm)) {

--- a/src/styles/modules/PageSection.module.css
+++ b/src/styles/modules/PageSection.module.css
@@ -1,5 +1,5 @@
 .page_section {
-  max-width: 900px;
+  max-width: 750px;
   padding: 2rem 0.5rem;
   margin: auto;
 }


### PR DESCRIPTION
<!-- 標準的なテンプレートなので、必ずしも埋める必要はない -->

## 関連 URL(jira/wiki/issue)

## 内容・背景
ルーズリーフの表現のためにパンチ穴の追加、及び周辺の微調整。
## 変更点

<!-- 画面キャプチャや動画があれば添付する -->

### as-is
![localhost_3000_about - Google Chrome 2022_10_02 2_01_02](https://user-images.githubusercontent.com/94683844/193420516-aebec186-ff6e-42b5-986f-9373465e66f7.png)
### to-be
![localhost_3000_about - Google Chrome 2022_10_02 2_01_22](https://user-images.githubusercontent.com/94683844/193420523-b91992cc-51cb-4933-b568-eb008d5a6575.png)

## テスト方法
Skillページ、Aboutページを表示する。
<!-- 動作確認の手順を記載する、画面キャプチャや動画もあれば添付する、テストコードの内容を記載しても可 -->

## レビュー観点

<!-- レビューする際の注意点や、詳しく見てほしい点などを記載する -->
Clipboard.module.cssの .clipboard__contents部分に変更があります。