### PR TITLE
Fix dom unmatch error

### DIFF
--- a/src/__tests__/utils/setCssVariable.spec.ts
+++ b/src/__tests__/utils/setCssVariable.spec.ts
@@ -1,0 +1,22 @@
+import { setCssVariable } from '@/utils/setCssVariable'
+
+describe(setCssVariable.name, () => {
+  it('should set css variable', () => {
+    const targetProperty = {
+      name: '--primary-main',
+      value: '#2196f3'
+    }
+
+    setCssVariable(targetProperty)
+    expect(getComputedStyle(document.documentElement).getPropertyValue(targetProperty.name)).toEqual(targetProperty.value)
+  })
+
+  it('should throw error because of validation error', () => {
+    expect(() =>
+      setCssVariable({
+        name: 'primary-main',
+        value: '#2196f3'
+      })
+    ).toThrow(/^CSS variable must begin with a "--"$/)
+  })
+})

--- a/src/components/molecules/Clipboard.tsx
+++ b/src/components/molecules/Clipboard.tsx
@@ -1,6 +1,9 @@
+import { useLayoutEffect } from 'react'
+
 import styles from '@/styles/modules/Clipboard.module.css'
 
 import { getNowDateString } from '@/utils/getNowDateString'
+import { setCssVariable } from '@/utils/setCssVariable'
 
 import type { FC, ReactNode } from 'react'
 
@@ -11,13 +14,15 @@ type Props = {
 }
 
 export const Clipboard: FC<Props> = ({ name, children, pinColor }) => {
-  // TODO: サーバーとクライアントの出力HTMLが不一致になる問題を解決する
-  const rollingDegree = `${Math.floor(Math.random() * (40 + 1 - 15)) + 15}deg`
+  useLayoutEffect(() => {
+    setCssVariable({ name: '--rolling-degree', value: `${Math.floor(Math.random() * (40 + 1 - 15)) + 15}deg` })
+    if (pinColor) {
+      setCssVariable({ name: '--pin-color', value: pinColor })
+    }
+  }, [pinColor])
 
   return (
-    // NOTE: styleプロパティからCSS変数を追加するためts-ignoreしている。
-    // @ts-ignore
-    <div className={styles.clipboard} style={{ '--rolling-degree': rollingDegree, ...(pinColor && { '--pin-color': pinColor }) }}>
+    <div className={styles.clipboard}>
       <div className={styles.clipboard__pin} />
 
       <div className={styles.clipboard__contents}>

--- a/src/components/templates/MainWithHeaderAndFooter.tsx
+++ b/src/components/templates/MainWithHeaderAndFooter.tsx
@@ -6,6 +6,7 @@ import { ClipboardIcon } from '@/components/atoms/icons/ClipboardIcon'
 
 import { Footer } from '@/components/molecules/Footer'
 import { Header } from '@/components/molecules/Header'
+import { isSmartphone } from '@/utils/mediaQuery'
 
 import type { FC, ReactNode } from 'react'
 
@@ -22,7 +23,7 @@ export const MainWithHeaderAndFooter: FC<Props> = ({ children }) => {
       <Header />
       <main className={styles.layout__container}>
         {children}
-        {!isHome && <ClipboardIcon className={styles.layout__icon} width={150} fill="#B7CDE8" />}
+        {!isSmartphone && !isHome && <ClipboardIcon className={styles.layout__icon} width={150} fill="#B7CDE8" />}
       </main>
       <Footer />
     </div>

--- a/src/hooks/useSetThemeToCssVariables.ts
+++ b/src/hooks/useSetThemeToCssVariables.ts
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 
 import { THEME } from '@/constants/theme'
+import { setCssVariable } from '@/utils/setCssVariable'
 
 export const useSetThemeToCssVariables = () => {
-  useEffect(() => {
+  useLayoutEffect(() => {
     const { colors, breakpoints } = THEME
 
     const convertedColors = Object.entries(colors).flatMap(([category, values]) => Object.entries(values).map(([name, value]) => [`--${category}-${name}`, value]))
@@ -12,8 +13,6 @@ export const useSetThemeToCssVariables = () => {
     // NOTE: valueが [CSS変数名, 値] になるようにする
     const convertedThemeVariables = [...convertedColors, ...convertedBreakpoints]
 
-    convertedThemeVariables.forEach(([name, value]) => {
-      document.documentElement.style.setProperty(name, value)
-    })
+    convertedThemeVariables.forEach(([name, value]) => setCssVariable({ name, value }))
   }, [])
 }

--- a/src/utils/mediaQuery.ts
+++ b/src/utils/mediaQuery.ts
@@ -1,0 +1,3 @@
+import { THEME } from '@/constants/theme'
+
+export const isSmartphone = typeof window !== 'undefined' && window.matchMedia(`(max-width: ${THEME.breakpoints.sm}px)`).matches

--- a/src/utils/setCssVariable.ts
+++ b/src/utils/setCssVariable.ts
@@ -1,0 +1,9 @@
+export const setCssVariable = ({ name, value }: { name: string; value: string | number }) => {
+  const prefix = name.substring(0, 2)
+
+  if (prefix !== '--') {
+    throw new Error('CSS variable must begin with a "--"')
+  }
+
+  document.documentElement.style.setProperty(name, `${value}`)
+}


### PR DESCRIPTION
<!-- 標準的なテンプレートなので、必ずしも埋める必要はない -->

## 関連 URL(jira/wiki/issue)
#24 

## 内容・背景
クリップボードがレンダリングされた時、サーバーで生成されたHTMLとクライアントで描画されたHTMLに差異が発生しエラーになっていた。

## 変更点
SSR時にタグにCSS変数を埋め込むのではなく、`useLayoutEffect`にてクライアント側で描画時に行うようにした。

<!-- 画面キャプチャや動画があれば添付する -->

### as-is

### to-be

## テスト方法
- [src/__tests__/utils/setCssVariable.spec.ts](https://github.com/mskw-nori/my-portfolio-site/pull/23/files#diff-a5cb66e763617da2869f7aeb8dec689369e6051e599d826237ec5f9824a26d16)
  - `yarn jest __tests__/utils/setCssVariable.spec.ts`

<!-- 動作確認の手順を記載する、画面キャプチャや動画もあれば添付する、テストコードの内容を記載しても可 -->

## レビュー観点

<!-- レビューする際の注意点や、詳しく見てほしい点などを記載する -->
